### PR TITLE
Add Non-Retriable Error Handling to Worker

### DIFF
--- a/lib/pulsar_ex/middlewares.ex
+++ b/lib/pulsar_ex/middlewares.ex
@@ -104,6 +104,12 @@ defmodule PulsarEx.Middlewares.Logging do
               "finished processing job with duration #{duration}ms, on cluster #{cluster}, #{inspect(result)}"
             )
 
+          {:non_retriable_error, err} ->
+            Logger.error(
+              "(non-retriable) error processing job with duration #{duration}ms, on cluster #{cluster}, #{inspect(err)}",
+              payload: job_state.payload
+            )
+
           state ->
             Logger.error(
               "error processing job with duration #{duration}ms, on cluster #{cluster}, #{inspect(state)}",
@@ -134,6 +140,12 @@ defmodule PulsarEx.Middlewares.Logging do
           {:ok, result} ->
             Logger.info(
               "finished processing job #{job} with duration #{duration}ms, on cluster #{cluster}, #{inspect(result)}"
+            )
+
+          {:non_retriable_error, err} ->
+            Logger.error(
+              "(non-retriable) error processing job #{job} with duration #{duration}ms, on cluster #{cluster}, #{inspect(err)}",
+              payload: job_state.payload
             )
 
           state ->
@@ -179,6 +191,13 @@ defmodule PulsarEx.Middlewares.Telemetry do
           :telemetry.execute(
             [:pulsar_ex, :worker, :handle_job, :success],
             %{count: 1, duration: System.monotonic_time() - start},
+            metadata
+          )
+
+        %JobState{state: {:non_retriable_error, _}} ->
+          :telemetry.execute(
+            [:pulsar_ex, :worker, :handle_job, :non_retriable, :error],
+            %{count: 1},
             metadata
           )
 


### PR DESCRIPTION
Introduce explicit handling of non-retriable errors in PulsarEx.Worker
- Define a list of errors that should not be retried
- Add telemetry event for non-retriable errors
- Modify consumer tracking to acknowledge non-retriable errors
- Log and send non-retriable errors to dead letter topic